### PR TITLE
winflexbison 2.5.25 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
     - cmake
     - m2-patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja
     - cmake
+    - m2-patch
 
 test:
   commands:
@@ -36,8 +37,12 @@ about:
   license_file:
     - bison/src/COPYING
     - flex/src/COPYING
+  dev_url: https://github.com/lexxmark/winflexbison
+  doc_url: https://www.gnu.org/software/bison/manual/
   summary: |
     WinFlexBison is a Windows port of Flex (the fast lexical analyser) and GNU Bison (parser generator).
+  description: |
+    WinFlexBison is a Windows port of Flex (the fast lexical analyser) and GNU Bison (parser generator). Both win_flex and win_bison are based on upstream sources but depend on system libraries only.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
winflexbison 2.5.25 

**Destination channel:** Defaults

### Links

- [PKG-8547]
- dev_url:        https://github.com/lexxmark/winflexbison/tree/v2.5.25
- conda_forge:    https://github.com/conda-forge/winflexbison-feedstock
- pypi:           https://pypi.org/project/winflexbison/2.5.25
- pypi inspector: https://inspector.pypi.io/project/winflexbison/2.5.25/

### Explanation of changes:

- new version number


[PKG-8547]: https://anaconda.atlassian.net/browse/PKG-8547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ